### PR TITLE
On test failure we want to keep all other tests running (setup should be done in grunt to stop on failure)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fc-grunt-protractor-webdriver",
+  "name": "grunt-protractor-webdriver",
   "description": "grunt plugin for starting Protractor's bundled Selenium Webdriver",
   "version": "0.1.6",
   "homepage": "https://github.com/seckardt/grunt-protractor-webdriver",


### PR DESCRIPTION
I'm just logging the error as warn but keep selenium open so other tests are processed.
