### PR TITLE
Fixing test execution in windows.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,7 +61,7 @@ module.exports = function (grunt) {
 				options: {
 					stdout: true
 				},
-				command: path.resolve('node_modules/protractor/bin/webdriver-manager') + ' update --standalone --chrome'
+				command: 'node ' + path.resolve('node_modules/protractor/bin/webdriver-manager') + ' update --standalone --chrome'
 			}
 		}
 	});


### PR DESCRIPTION
Fixing test execution in windows.
Always use `node command` to execute commands. Instead of this, you'll get:

```
Warning: Command failed: 'c:\git\clients\pruebas\node_modules\grunt-protractor-webdrive\node_modules\protractor\bin\webdriver-manager' is not recognized as an internal or external command, operable program or batch file. Use --force to continue.
```
